### PR TITLE
Fix gradle dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,6 +14,7 @@ android {
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"
+        multiDexEnabled true
 
         testInstrumentationRunner "com.takeaway.assignment.CustomTestRunner"
     }
@@ -57,6 +58,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:$swipeRefreshLayoutVersion"
     implementation "androidx.test.espresso:espresso-idling-resource:$espressoVersion"
+    implementation "androidx.multidex:multidex:$multidexVersion"
 
 
     // Lifecycle
@@ -79,14 +81,11 @@ dependencies {
     // Hilt
     implementation "com.google.dagger:hilt-android:$hiltVersion"
     kapt "com.google.dagger:hilt-android-compiler:$hiltVersion"
-    implementation 'androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03'
-    kapt 'androidx.hilt:hilt-compiler:1.0.0'
 
     // Hilt testing
     androidTestImplementation "com.google.dagger:hilt-android-testing:$hiltVersion"
     testImplementation "com.google.dagger:hilt-android-testing:$hiltVersion"
     kaptAndroidTest "com.google.dagger:hilt-android-compiler:$hiltVersion"
-    kaptAndroidTest "androidx.hilt:hilt-compiler:1.0.0"
 
     // Unit Testing
     testImplementation "junit:junit:$junitVersion"
@@ -106,6 +105,9 @@ dependencies {
         exclude group: "com.pinterest.ktlint", module: "ktlint-core"
         exclude group: "com.pinterest.ktlint", module: "ktlint-ruleset-experimental"
         exclude group: "com.pinterest.ktlint", module: "ktlint-ruleset-standard"
+        exclude group: "org.jetbrains.kotlin", module: "kotlin-compiler-embeddable"
     }
-    implementation "io.gitlab.arturbosch.detekt:detekt-cli:$detektVersion"
+    implementation("io.gitlab.arturbosch.detekt:detekt-cli:$detektVersion") {
+        exclude group: "org.jetbrains.kotlin", module: "kotlin-compiler-embeddable"
+    }
 }

--- a/app/src/main/java/com/takeaway/assignment/AssignmentApplication.kt
+++ b/app/src/main/java/com/takeaway/assignment/AssignmentApplication.kt
@@ -1,11 +1,11 @@
 package com.takeaway.assignment
 
-import android.app.Application
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.multidex.MultiDexApplication
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class AssignmentApplication : Application() {
+class AssignmentApplication : MultiDexApplication() {
     override fun onCreate() {
         super.onCreate()
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)

--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,11 @@ buildscript {
     ext.detektVersion = "1.3.1"
     repositories {
         google()
-        jcenter()
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'
+        //noinspection DifferentKotlinGradleVersion
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hiltVersion"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detektVersion"
@@ -19,7 +19,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        maven { url "https://plugins.gradle.org/m2/" }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,6 +32,7 @@ coroutinesVersion=1.4.2
 lifecycleVersion=2.2.0
 lifecycleKtxVersion=2.3.1
 fragmentKtxVersion=1.3.5
+multidexVersion=2.0.1
 
 # Testing
 junitVersion=4.13.2


### PR DESCRIPTION
- Resolved changes with detekt dependencies by excluding some of the libraries used in it.
- Enabled multidex.
- Removed jcenter as repository in the app.
- Removed deprecated dagger hilt dependencies.